### PR TITLE
fix: correct Netlify badge URLs and add Powered by Netlify to header/footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # HLS Player for Moodle
 
-![CI](https://github.com/kackey621/moodle-mod_hlsplayer/actions/workflows/ci.yml/badge.svg)
-[![Deploys by Netlify](https://www.netlify.com/img/global/badges/netlify-color-bg.svg)](https://www.netlify.com)
+[![CI](https://github.com/kackey621/moodle-mod_hlsplayer/actions/workflows/ci.yml/badge.svg)](https://github.com/kackey621/moodle-mod_hlsplayer/actions)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](hlsplayer/LICENSE)
-[![Code of Conduct](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![Deploys by Netlify](https://www.netlify.com/assets/badges/netlify-badge-light.svg)](https://www.netlify.com)
 
 A Moodle activity module that enables HLS (HTTP Live Streaming) video playback using Video.js. This plugin supports `.m3u8` playlists from both external URLs and file uploads. It includes advanced features for education, such as seek restrictions, progress tracking, and automatic completion based on watch percentage.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,15 @@
 
 [![CI](https://github.com/kackey621/moodle-mod_hlsplayer/actions/workflows/ci.yml/badge.svg)](https://github.com/kackey621/moodle-mod_hlsplayer/actions)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://github.com/kackey621/moodle-mod_hlsplayer/blob/main/hlsplayer/LICENSE)
-[![Code of Conduct](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code-of-conduct.md)
-[![Deploys by Netlify](https://www.netlify.com/img/global/badges/netlify-color-bg.svg)](https://www.netlify.com)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code-of-conduct.md)
+[![Deploys by Netlify](https://www.netlify.com/assets/badges/netlify-badge-light.svg)](https://www.netlify.com)
+
+<div style="margin: 0.5rem 0 1rem;">
+  <a href="https://www.netlify.com" target="_blank" rel="noopener">
+    <img src="https://www.netlify.com/assets/badges/netlify-badge-light.svg" alt="This site is powered by Netlify" style="height:2rem;">
+  </a>
+  <span style="margin-left: 0.5rem; font-size: 0.85rem; color: var(--md-default-fg-color--light);">This site is powered by Netlify</span>
+</div>
 
 ---
 

--- a/hlsplayer/README.md
+++ b/hlsplayer/README.md
@@ -1,8 +1,8 @@
 # HLS Player for Moodle
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](../LICENSE)
-[![Code of Conduct](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](../CODE_OF_CONDUCT.md)
-[![Deploys by Netlify](https://www.netlify.com/img/global/badges/netlify-color-bg.svg)](https://www.netlify.com)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](../CODE_OF_CONDUCT.md)
+[![Deploys by Netlify](https://www.netlify.com/assets/badges/netlify-badge-light.svg)](https://www.netlify.com)
 
 The **HLS Player** is an activity module for Moodle that enables seamless playback of HTTP Live Streaming (HLS) videos (`.m3u8`) directly within a course. Designed for educational content delivery, it offers advanced features like progress tracking, completion conditions based on viewing percentage, and improved playback controls.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,10 +53,13 @@ copyright: >-
   Copyright &copy; 2025 hlsplayer contributors &mdash;
   <a href="https://github.com/kackey621/moodle-mod_hlsplayer/blob/main/hlsplayer/LICENSE">GPL v3 or later</a>
   &mdash;
+  <a href="/code-of-conduct/">Code of Conduct</a>
+  &mdash;
+  <a href="https://www.netlify.com" target="_blank" rel="noopener">This site is powered by Netlify</a>
   <a href="https://www.netlify.com" target="_blank" rel="noopener">
-    <img src="https://www.netlify.com/img/global/badges/netlify-color-bg.svg"
+    <img src="https://www.netlify.com/assets/badges/netlify-badge-light.svg"
          alt="Deploys by Netlify"
-         style="height:1.2em; vertical-align:middle; margin-left:4px;">
+         style="height:1.2em; vertical-align:middle; margin-left:6px;">
   </a>
 
 plugins:


### PR DESCRIPTION
## Summary

PR #12 のドキュメント追加後に発見された問題の修正。

- **Netlify バッジ URL を修正** — `netlify-color-bg.svg`（404）→ `netlify-badge-light.svg`（200）
  - `README.md`, `hlsplayer/README.md`, `docs/index.md`, `mkdocs.yml` の4箇所
- **`docs/index.md` ホームページ先頭** に "This site is powered by Netlify" バッジ＋テキストを追加
- **mkdocs フッター（全ページ）** に以下を追加：
  - `Code of Conduct` リンク
  - "This site is powered by Netlify" テキスト＋バッジ

## Netlify Open Source Plan Compliance (更新後)

| 要件 | 対応状況 |
|------|---------|
| OSI ライセンス (GPL v3) | ✅ フッターにリンク |
| Code of Conduct | ✅ ナビゲーション＋フッター（全ページ）＋ホームページ |
| Netlify リンク（メインページ or 全ページ） | ✅ ホームページ先頭＋全ページフッター（テキスト＋バッジ） |
| 非商用 | ✅ |

## Test Plan

- [ ] `mkdocs serve` でローカルビルドが通ること
- [ ] `docs/index.md` にバッジとテキストが表示されること
- [ ] 全ページのフッターに "This site is powered by Netlify" と CoC リンクが表示されること
- [ ] README.md のバッジが GitHub 上で正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)